### PR TITLE
change to startswith matching of entries

### DIFF
--- a/client.py
+++ b/client.py
@@ -9,7 +9,7 @@ import difflib
 import os
 import argparse
 
-version = 10
+version = 11
 
 limit_traffic = True
 

--- a/server.py
+++ b/server.py
@@ -6,7 +6,7 @@ import git
 import json
 import sys
 
-VERSION = 10
+VERSION = 11
 
 app = Flask(__name__)
 tokens = True

--- a/server.py
+++ b/server.py
@@ -52,7 +52,9 @@ def get_duplicates(entry):
 
 def entry_by_key(key):
     for entry in bib_database.entries:
-        if entry["ID"] == key:
+        if entry["ID"].startswith(key):
+            return entry
+        if key.startswith(entry["ID"]):
             return entry
     return None
 


### PR DESCRIPTION
this implies that the database is clean and no key can be the prefix of another key, because they would match now.